### PR TITLE
feat: 로그인/회원가입 페이지 UI/UX 개선 및 기능 추가

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -21,9 +21,11 @@
         "d3": "^7.9.0",
         "lucide-react": "^0.507.0",
         "next": "15.2.2",
+        "next-themes": "^0.4.6",
         "postcss": "^8.5.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "sonner": "^2.0.6",
         "tailwind-merge": "^3.2.0"
       },
       "devDependencies": {
@@ -6322,6 +6324,16 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -7225,6 +7237,16 @@
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.6.tgz",
+      "integrity": "sha512-yHFhk8T/DK3YxjFQXIrcHT1rGEeTLliVzWbO0xN8GberVun2RiBnxAjXAYpZrqwEVHBG9asI/Li8TAAhN9m59Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/front/package.json
+++ b/front/package.json
@@ -22,9 +22,11 @@
     "d3": "^7.9.0",
     "lucide-react": "^0.507.0",
     "next": "15.2.2",
+    "next-themes": "^0.4.6",
     "postcss": "^8.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sonner": "^2.0.6",
     "tailwind-merge": "^3.2.0"
   },
   "devDependencies": {

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -1,24 +1,31 @@
-// app/layout.tsx
+"use client";
+
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
+import { usePathname } from "next/navigation";
 import "./globals.css";
+import { Toaster } from "sonner"; // Toaster import 추가
 
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const pathname = usePathname();
+  const showSidebar = !["/login", "/register"].includes(pathname);
+
   return (
     <html lang="en">
       <body>
-        <div className="flex h-screen">
-          <SidebarProvider>
-            <AppSidebar />
-            <main className="flex-1">
-              {children}
-            </main>
-          </SidebarProvider>
-        </div>
+        <SidebarProvider> {/* SidebarProvider가 전체 flex 컨테이너를 감쌉니다. */}
+          <div className="flex w-full h-screen">
+            {showSidebar && (
+              <AppSidebar /> 
+            )}
+            <main className="flex-1 items-center">{children}</main>
+          </div>
+        </SidebarProvider>
+        <Toaster /> {/* Toaster 컴포넌트 추가 */}
       </body>
     </html>
   );

--- a/front/src/app/login/page.tsx
+++ b/front/src/app/login/page.tsx
@@ -1,6 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import LoginForm from "@/components/LoginForm";
 
 export default function LoginPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (token) {
+      router.push("/home");
+    }
+  }, [router]);
+
   return (
     <>
       <LoginForm />

--- a/front/src/app/login/page.tsx
+++ b/front/src/app/login/page.tsx
@@ -1,22 +1,15 @@
-"use client";
-
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import LoginForm from "@/components/LoginForm";
+import Link from 'next/link';
 
 export default function LoginPage() {
-  const router = useRouter();
-
-  useEffect(() => {
-    const token = localStorage.getItem("token");
-    if (token) {
-      router.push("/home");
-    }
-  }, [router]);
-
   return (
-    <>
-      <LoginForm />
-    </>
+    <div className="flex flex-col min-h-screen bg-white text-gray-900">
+      <header className="w-full p-4 bg-white text-gray-900 flex items-center justify-between border-gray-200">
+        <Link href="/" className="text-2xl font-bold">ChatGraph</Link>
+      </header>
+      <main className=" flex items-center max-w-xl justify-center">
+        <LoginForm />
+      </main>
+    </div>
   );
 }

--- a/front/src/app/register/page.tsx
+++ b/front/src/app/register/page.tsx
@@ -1,6 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import RegisterForm from "@/components/RegisterForm";
 
 export default function Register() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (token) {
+      router.push("/home");
+    }
+  }, [router]);
+
   return (
     <>
       <RegisterForm />

--- a/front/src/app/register/page.tsx
+++ b/front/src/app/register/page.tsx
@@ -1,22 +1,16 @@
-"use client";
-
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import RegisterForm from "@/components/RegisterForm";
+import Link from 'next/link';
 
-export default function Register() {
-  const router = useRouter();
-
-  useEffect(() => {
-    const token = localStorage.getItem("token");
-    if (token) {
-      router.push("/home");
-    }
-  }, [router]);
-
+export default function RegisterPage() {
   return (
-    <>
-      <RegisterForm />
-    </>
+    <div className="flex flex-col min-h-screen bg-white text-gray-900">
+      <header className="w-full p-4 bg-white text-gray-900 flex items-center justify-between  border-gray-200">
+        <Link href="/" className="text-2xl font-bold">ChatGraph</Link>
+
+      </header>
+      <main className="flex items-center justify-center">
+        <RegisterForm />
+      </main>
+    </div>
   );
 }

--- a/front/src/components/LoginForm.tsx
+++ b/front/src/components/LoginForm.tsx
@@ -1,17 +1,16 @@
-"use client";
+"use client"
 
-import Link from "next/link";
-import { Button } from "./ui/button";
-import { Input } from "./ui/input";
-import { Label } from "./ui/label";
-import Image from "next/image";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { api } from "@/lib/api";
+import Link from 'next/link';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { api } from '@/lib/api';
 
-export default function LoginForm() {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+export default function LoginForm({ onSuccess }: { onSuccess?: () => void }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
 
   const router = useRouter();
 
@@ -19,7 +18,7 @@ export default function LoginForm() {
     e.preventDefault();
 
     try {
-      const res = await api.post("/login", {
+      const res = await api.post('/login', {
         email,
         password,
       });
@@ -27,30 +26,24 @@ export default function LoginForm() {
       if (res.status === 200) {
         const token = res.data.token;
         if (token) {
-          localStorage.setItem("token", token);
-          alert("로그인!");
-          router.push("/home");
+          localStorage.setItem('token', token);
+          alert('로그인!');
+          onSuccess?.();
+          router.push('/');
         }
       } else {
-        alert("로그인 실패");
+        alert('로그인 실패');
       }
     } catch (err) {
       console.error(err);
-      alert("로그인 오류 발생!");
+      alert('로그인 오류 발생!');
     }
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen px-4">
-      <Image
-        src="/chat-logo.png"
-        alt="로고"
-        width={100}
-        height={100}
-        className="mb-12"
-        priority
-      />
-      <h1 className="text-2xl font-bold mb-6 text-center">로그인</h1>
+    <div className="flex flex-col items-center px-4 py-12">
+      
+      
       <form className="w-full max-w-md space-y-4">
         {/* <div>
           <Label htmlFor="아이디" className="mb-2 pt-4 ml-1">
@@ -103,3 +96,4 @@ export default function LoginForm() {
     </div>
   );
 }
+

--- a/front/src/components/LoginForm.tsx
+++ b/front/src/components/LoginForm.tsx
@@ -7,15 +7,20 @@ import { Label } from './ui/label';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { api } from '@/lib/api';
+import { toast } from "sonner"; // sonner import 추가
+import { Loader2, CheckCircle } from "lucide-react"; // 로딩 아이콘 추가
 
-export default function LoginForm({ onSuccess }: { onSuccess?: () => void }) {
+export default function LoginForm() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [isLoading, setIsLoading] = useState(false); // 로딩 상태 추가
 
   const router = useRouter();
 
   const handelLogin = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    setIsLoading(true); // 로딩 시작
 
     try {
       const res = await api.post('/login', {
@@ -27,72 +32,78 @@ export default function LoginForm({ onSuccess }: { onSuccess?: () => void }) {
         const token = res.data.token;
         if (token) {
           localStorage.setItem('token', token);
-          alert('로그인!');
-          onSuccess?.();
-          router.push('/');
+          toast.success("로그인 성공!", { // sonner 성공 메시지
+            icon: <CheckCircle className="h-5 w-5" />,
+          });
+          router.push('/'); // /로 페이지 이동
         }
       } else {
-        alert('로그인 실패');
+        toast.error("로그인 실패"); // sonner 실패 메시지
       }
     } catch (err) {
       console.error(err);
-      alert('로그인 오류 발생!');
+      toast.error("로그인 중 오류가 발생했습니다"); // sonner 오류 메시지
+    } finally {
+      setIsLoading(false); // 로딩 종료
     }
   };
 
   return (
-    <div className="flex flex-col items-center px-4 py-12">
-      
-      
-      <form className="w-full max-w-md space-y-4">
-        {/* <div>
-          <Label htmlFor="아이디" className="mb-2 pt-4 ml-1">
-            아이디
-          </Label>
-          <Input
-            id="아이디"
-            placeholder="아이디"
-            type="text"
-            className="w-80 text-[10px]! border border-gray-500 focus:outline-none focus:ring-2! focus:ring-[#A599FF]! focus:border-[#A599FF]!"
-          />
-        </div> */}
-        <div>
-          <Label htmlFor="email" className="mb-2 pt-4 ml-1">
-            이메일
-          </Label>
-          <Input
-            id="email"
-            placeholder="ex) 123@gmail.com"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="w-80 text-[10px] border border-gray-500 focus:outline-none focus:ring-2 focus:ring-[#A599FF] focus:border-[#A599FF]"
-          />
-        </div>
-        <div>
-          <Label htmlFor="비밀번호" className="mb-2  pt-3 ml-1">
-            비밀번호
-          </Label>
-          <Input
-            id="비밀번호"
-            placeholder="비밀번호"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="w-80 text-[10px]! border border-gray-500 focus:outline-none focus:ring-2! focus:ring-[#A599FF]! focus:border-[#A599FF]!"
-          />
-        </div>
-        <div className="flex justify-between text-sm text-gray-500 px-1 text-[11px]">
-          <Link href="/find">아이디/비밀번호 찾기</Link>
-          <Link href="signup">회원가입</Link>
-        </div>
-        <Button
-          onClick={(e) => handelLogin(e)}
-          className="w-full bg-[#A599FF] hover:bg-[#8E7FFF]"
-        >
-          로그인
-        </Button>
-      </form>
+    <div className="flex flex-col items-center justify-center h-screen p-4 bg-white text-gray-900">
+      <div className="max-w-4xl w-full text-center space-y-6 p-8 rounded-lg shadow-lg bg-white border border-gray-200">
+        <h1 className="text-4xl font-bold">로그인</h1>
+        <p className="text-lg text-gray-600">
+          ChatGraph에 오신 것을 환영합니다.
+        </p>
+        <form className="w-full space-y-6" onSubmit={handelLogin}>
+          <div>
+            <Label htmlFor="email" className="block text-left text-base font-medium text-gray-700 mb-2">
+              이메일
+            </Label>
+            <Input
+              id="email"
+              placeholder="ex) 123@gmail.com"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-4 py-3 text-lg border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-gray-500 bg-gray-50 text-gray-900"
+            />
+          </div>
+          <div>
+            <Label htmlFor="password" className="block text-left text-base font-medium text-gray-700 mb-2">
+              비밀번호
+            </Label>
+            <Input
+              id="password"
+              placeholder="비밀번호"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full px-4 py-3 text-lg border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-gray-500 bg-gray-50 text-gray-900"
+            />
+          </div>
+          <Button
+            type="submit"
+            className="w-full py-3 text-lg font-semibold bg-gray-900 text-white rounded-lg hover:bg-gray-700 transition-colors duration-200"
+            disabled={isLoading} // 로딩 중 버튼 비활성화
+          >
+            {isLoading ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              ""
+            )}
+            로그인
+          </Button>
+          <div className="flex justify-between text-base text-gray-600 mt-4">
+            <Link href="/find" className="hover:underline">
+              아이디/비밀번호 찾기
+            </Link>
+            <Link href="/register" className="hover:underline">
+              회원가입
+            </Link>
+          </div>
+        </form>
+      </div>
     </div>
   );
 }

--- a/front/src/components/RegisterForm.tsx
+++ b/front/src/components/RegisterForm.tsx
@@ -1,4 +1,4 @@
-"use client";
+"use client"
 
 import { useState } from "react";
 import { Button } from "./ui/button";
@@ -6,18 +6,18 @@ import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { useRouter } from "next/navigation";
 import { api } from "@/lib/api";
+import { toast } from "sonner";
+import { Loader2, CheckCircle } from "lucide-react";
 
-export default function SignupForm({ onSuccess }: { onSuccess?: () => void }) {
+export default function SignupForm() {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [passwordCheck, setPasswordCheck] = useState(""); // 비밀번호 확인 상태 추가
   const [passwordError, setPasswordError] = useState("");
-  // const [name, setName] = useState("");
-  // const [id, setId] = useState("");
-  // const [passwordCheck, setPasswordCheck] = useState("");
-  // const [matchError, setMatchError] = useState("");
+  const [matchError, setMatchError] = useState(""); // 비밀번호 일치 오류 상태 추가
+  const [isLoading, setIsLoading] = useState(false);
 
-  //   비밀번호 유효성 검사
   const isValidPassword = (pwd: string) => {
     const regex =
       /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?])[A-Za-z\d!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]{8,16}$/;
@@ -26,11 +26,12 @@ export default function SignupForm({ onSuccess }: { onSuccess?: () => void }) {
 
   const handleSignup = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log("handleSignup 실행");
 
-    if (passwordError) {
+    if (passwordError || matchError || !email || !password || !passwordCheck) { // 유효성 검사 추가
       return;
     }
+
+    setIsLoading(true);
 
     try {
       const res = await api.post("/signup", {
@@ -39,140 +40,128 @@ export default function SignupForm({ onSuccess }: { onSuccess?: () => void }) {
       });
 
       if (res.status === 200) {
-        alert("가입 완료!");
-        onSuccess?.();
-        router.push("/");
+        toast.success("회원가입이 완료되었습니다", {
+          icon: <CheckCircle className="h-5 w-5" />,
+        });
+        router.push("/login");
       } else {
-        alert("회원가입에 실패했습니다");
+        toast.error("회원가입에 실패했습니다");
       }
     } catch (error) {
       console.error(error);
-      alert("회원가입 중 오류가 발생했습니다");
+      toast.error("회원가입 중 오류가 발생했습니다");
+    } finally {
+      setIsLoading(false);
     }
-    // if (!name || !email || !id || !password || !passwordCheck) {
-    //   alert("모든 항목을 입력해주세요.");
-    //   return;
-    // }
   };
 
-
   return (
-    <div className="flex flex-col items-center px-4 py-12">
-      
-      
-
-      <form onSubmit={handleSignup} className="w-full max-w-md space-y-4">
-        {/* <div>
-          <Label htmlFor="name" className="mb-2 pt-4 ml-1">
-            이름
-          </Label>
-          <Input
-            id="name"
-            placeholder="이름"
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className="w-80 text-[10px] border border-gray-500 focus:outline-none focus:ring-2 focus:ring-[#A599FF] focus:border-[#A599FF]"
-          />
-        </div> */}
-
-        <div>
-          <Label htmlFor="email" className="mb-2 pt-4 ml-1">
-            이메일
-          </Label>
-          <Input
-            id="email"
-            placeholder="ex) 123@gmail.com"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="w-80 text-[10px] border border-gray-500 focus:outline-none focus:ring-2 focus:ring-[#A599FF] focus:border-[#A599FF]"
-          />
-        </div>
-
-        {/* <div>
-          <Label htmlFor="id" className="mb-2 pt-4 ml-1">
-            아이디
-          </Label>
-          <Input
-            id="id"
-            placeholder="아이디"
-            type="text"
-            value={id}
-            onChange={(e) => setId(e.target.value)}
-            className="w-80 text-[10px] border border-gray-500 focus:outline-none focus:ring-2 focus:ring-[#A599FF] focus:border-[#A599FF]"
-          />
-        </div> */}
-
-        <div>
-          <Label htmlFor="password" className="mb-2 pt-3 ml-1">
-            비밀번호
-          </Label>
-          <Input
-            id="password"
-            placeholder="비밀번호"
-            type="password"
-            value={password}
-            onChange={(e) => {
-              setPassword(e.target.value);
-              setPasswordError("");
-            }}
-            onBlur={() => {
-              if (!isValidPassword(password)) {
-                setPasswordError(
-                  "비밀번호는 8~16자, 대소문자/숫자/특수문자를 포함해야 합니다."
-                );
-              }
-            }}
-            autoComplete="new-password"
-            className="w-80 text-[10px] border border-gray-500 focus:outline-none focus:ring-2 focus:ring-[#A599FF] focus:border-[#A599FF]"
-          />
-
-          <div className="text-[9px] ml-1 mt-1 text-gray-500">
-            8~16자의 영문 대소문자, 숫자, 특수문자
+    <div className="flex flex-col items-center justify-center h-screen p-4 bg-white text-gray-900">
+      <div className="max-w-4xl w-full text-center space-y-6 p-8 rounded-lg shadow-lg bg-white border border-gray-200">
+        <h1 className="text-4xl font-bold">회원가입</h1>
+        <p className="text-lg text-gray-600">
+          ChatGraph에 오신 것을 환영합니다.
+        </p>
+        <form onSubmit={handleSignup} className="w-full space-y-6">
+          <div>
+            <Label htmlFor="email" className="block text-left text-base font-medium text-gray-700 mb-2">
+              이메일
+            </Label>
+            <Input
+              id="email"
+              placeholder="ex) 123@gmail.com"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-4 py-3 text-lg border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-gray-500 bg-gray-50 text-gray-900"
+            />
           </div>
-          {passwordError && (
-            <div className="text-[9px] text-red-500 mt-1 ml-1">
-              {passwordError}
-            </div>
-          )}
-        </div>
 
-        {/* <div>
-          <Label htmlFor="passwordCheck" className="mb-2 pt-4 ml-1">
-            비밀번호 확인
-          </Label>
-          <Input
-            id="passwordCheck"
-            value={passwordCheck}
-            placeholder="비밀번호 확인"
-            onChange={(e) => {
-              setPasswordCheck(e.target.value);
-              setMatchError(""); // 입력 시 에러 초기화
-            }}
-            onBlur={() => {
-              if (password !== passwordCheck) {
-                setMatchError("비밀번호가 일치하지 않습니다.");
-              }
-            }}
-            type="password"
-            autoComplete="new-password"
-            className="w-80 text-[10px] border border-gray-500 focus:outline-none focus:ring-2 focus:ring-[#A599FF] focus:border-[#A599FF]"
-          />
-          {matchError && (
-            <div className="text-[9px] text-red-500 mt-1 ml-1">
-              {matchError}
-            </div>
-          )}
-        </div> */}
+          <div>
+            <Label htmlFor="password" className="block text-left text-base font-medium text-gray-700 mb-2">
+              비밀번호
+            </Label>
+            <Input
+              id="password"
+              placeholder="비밀번호"
+              type="password"
+              value={password}
+              onChange={(e) => {
+                setPassword(e.target.value);
+                setPasswordError("");
+                if (passwordCheck && e.target.value !== passwordCheck) {
+                  setMatchError("비밀번호가 일치하지 않습니다.");
+                } else {
+                  setMatchError("");
+                }
+              }}
+              onBlur={() => {
+                if (!isValidPassword(password)) {
+                  setPasswordError(
+                    "비밀번호는 8~16자, 대소문자/숫자/특수문자를 포함해야 합니다."
+                  );
+                }
+              }}
+              autoComplete="new-password"
+              className="w-full px-4 py-3 text-lg border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-gray-500 bg-gray-50 text-gray-900"
+            />
 
-        <Button
-          type="submit"
-          className="w-full bg-[#A599FF] hover:bg-[#8E7FFF]"
-        >
-          회원가입
-        </Button>
-      </form>
+            <div className="text-sm text-gray-500 mt-2 text-left">
+              8~16자의 영문 대소문자, 숫자, 특수문자
+            </div>
+            {passwordError && (
+              <div className="text-sm text-red-500 mt-2 text-left">
+                {passwordError}
+              </div>
+            )}
+          </div>
+
+          <div>
+            <Label htmlFor="passwordCheck" className="block text-left text-base font-medium text-gray-700 mb-2">
+              비밀번호 확인
+            </Label>
+            <Input
+              id="passwordCheck"
+              placeholder="비밀번호 확인"
+              type="password"
+              value={passwordCheck}
+              onChange={(e) => {
+                setPasswordCheck(e.target.value);
+                if (password && e.target.value !== password) {
+                  setMatchError("비밀번호가 일치하지 않습니다.");
+                } else {
+                  setMatchError("");
+                }
+              }}
+              onBlur={() => {
+                if (password && passwordCheck && password !== passwordCheck) {
+                  setMatchError("비밀번호가 일치하지 않습니다.");
+                }
+              }}
+              autoComplete="new-password"
+              className="w-full px-4 py-3 text-lg border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-gray-500 bg-gray-50 text-gray-900"
+            />
+            {matchError && (
+              <div className="text-sm text-red-500 mt-2 text-left">
+                {matchError}
+              </div>
+            )}
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full py-3 text-lg font-semibold bg-gray-900 text-white rounded-lg hover:bg-gray-700 transition-colors duration-200"
+            disabled={isLoading || !!passwordError || !!matchError || !email || !password || !passwordCheck} // 버튼 비활성화 조건 추가
+          >
+            {isLoading ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              ""
+            )}
+            회원가입
+          </Button>
+        </form>
+      </div>
     </div>
   );
 }

--- a/front/src/components/RegisterForm.tsx
+++ b/front/src/components/RegisterForm.tsx
@@ -4,11 +4,10 @@ import { useState } from "react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { api } from "@/lib/api";
 
-export default function SignupForm() {
+export default function SignupForm({ onSuccess }: { onSuccess?: () => void }) {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -41,7 +40,8 @@ export default function SignupForm() {
 
       if (res.status === 200) {
         alert("가입 완료!");
-        router.push("/login");
+        onSuccess?.();
+        router.push("/");
       } else {
         alert("회원가입에 실패했습니다");
       }
@@ -55,17 +55,11 @@ export default function SignupForm() {
     // }
   };
 
+
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen px-4">
-      <Image
-        src="/chat-logo.png"
-        alt="로고"
-        width={100}
-        height={100}
-        className="mb-8"
-        priority
-      />
-      <h1 className="text-2xl font-bold mb-6 text-center">회원가입</h1>
+    <div className="flex flex-col items-center px-4 py-12">
+      
+      
 
       <form onSubmit={handleSignup} className="w-full max-w-md space-y-4">
         {/* <div>

--- a/front/src/components/app-sidebar.tsx
+++ b/front/src/components/app-sidebar.tsx
@@ -41,15 +41,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import LoginForm from "./LoginForm";
-import RegisterForm from "./RegisterForm";
 
 export function AppSidebar() {
   const { state, toggleSidebar } = useSidebar();
@@ -223,44 +214,20 @@ export function AppSidebar() {
           ) : (
             <>
               <SidebarMenuItem>
-                <Dialog>
-                  <DialogTrigger asChild>
-                    <SidebarMenuButton>
-                      <LogIn />
-                      {state === "expanded" && <span>로그인</span>}
-                    </SidebarMenuButton>
-                  </DialogTrigger>
-                  <DialogContent>
-                    <DialogHeader>
-                      <DialogTitle>로그인</DialogTitle>
-                    </DialogHeader>
-                    <LoginForm
-                      onSuccess={() => {
-                        setIsLoggedIn(true);
-                      }}
-                    />
-                  </DialogContent>
-                </Dialog>
+                <SidebarMenuButton asChild>
+                  <Link href="/login">
+                    <LogIn />
+                    {state === "expanded" && <span>로그인</span>}
+                  </Link>
+                </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem>
-                <Dialog>
-                  <DialogTrigger asChild>
-                    <SidebarMenuButton>
-                      <UserPlus />
-                      {state === "expanded" && <span>회원가입</span>}
-                    </SidebarMenuButton>
-                  </DialogTrigger>
-                  <DialogContent>
-                    <DialogHeader>
-                      <DialogTitle>회원가입</DialogTitle>
-                    </DialogHeader>
-                    <RegisterForm
-                      onSuccess={() => {
-                        setIsLoggedIn(true);
-                      }}
-                    />
-                  </DialogContent>
-                </Dialog>
+                <SidebarMenuButton asChild>
+                  <Link href="/register">
+                    <UserPlus />
+                    {state === "expanded" && <span>회원가입</span>}
+                  </Link>
+                </SidebarMenuButton>
               </SidebarMenuItem>
             </>
           )}

--- a/front/src/components/app-sidebar.tsx
+++ b/front/src/components/app-sidebar.tsx
@@ -1,6 +1,6 @@
-"use client"
+"use client";
 
-import { useState } from "react"
+import { useEffect, useState } from "react";
 import {
   Sidebar,
   SidebarHeader,
@@ -16,15 +16,15 @@ import {
   SidebarTrigger,
   useSidebar,
   SidebarInput,
-} from "@/components/ui/sidebar"
-import { Button } from "@/components/ui/button"
+} from "@/components/ui/sidebar";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
-} from "@/components/ui/dropdown-menu"
-import Link from "next/link"
+} from "@/components/ui/dropdown-menu";
+import Link from "next/link";
 import {
   User2,
   ChevronUp,
@@ -33,12 +33,34 @@ import {
   Search,
   MessageSquare,
   PanelLeftOpen,
-} from "lucide-react"
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+  LogIn,
+  UserPlus,
+} from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import LoginForm from "./LoginForm";
+import RegisterForm from "./RegisterForm";
 
 export function AppSidebar() {
-  const { state, toggleSidebar } = useSidebar()
-  const [isSearchVisible, setIsSearchVisible] = useState(false)
+  const { state, toggleSidebar } = useSidebar();
+  const [isSearchVisible, setIsSearchVisible] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    setIsLoggedIn(!!token);
+  }, []);
+
   const allProjects = [
     {
       name: "DB 정규화 방법",
@@ -52,24 +74,30 @@ export function AppSidebar() {
       name: "IPv4 프로토콜 개요",
       url: "/3",
     },
-  ]
+  ];
 
-  const [projects, setProjects] = useState(allProjects)
-  const [searchTerm, setSearchTerm] = useState("")
+  const [projects, setProjects] = useState(allProjects);
+  const [searchTerm, setSearchTerm] = useState("");
 
   const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const term = event.target.value.toLowerCase()
-    setSearchTerm(term)
+    const term = event.target.value.toLowerCase();
+    setSearchTerm(term);
     if (term) {
       setProjects(
         allProjects.filter((project) =>
           project.name.toLowerCase().includes(term)
         )
-      )
+      );
     } else {
-      setProjects(allProjects)
+      setProjects(allProjects);
     }
-  }
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem("token");
+    setIsLoggedIn(false);
+    alert("로그아웃 되었습니다.");
+  };
 
   return (
     <Sidebar collapsible="icon">
@@ -108,7 +136,7 @@ export function AppSidebar() {
               <Search />
               <span>Search</span>
             </SidebarMenuButton>
-            {isSearchVisible && state === 'expanded' && (
+            {isSearchVisible && state === "expanded" && (
               <div className="mt-2">
                 <SidebarInput
                   placeholder="Search..."
@@ -166,33 +194,78 @@ export function AppSidebar() {
 
       <SidebarFooter className="p-2">
         <SidebarMenu>
-          <SidebarMenuItem>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <SidebarMenuButton>
-                  <User2 />
-                  {state === "expanded" && <span>Username</span>}
-                  {state === "expanded" && <ChevronUp className="ml-auto" />}
-                </SidebarMenuButton>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
-                side="top"
-                className="w-[--radix-popper-anchor-width]"
-              >
-                <DropdownMenuItem>
-                  <span>Account</span>
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <span>Billing</span>
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <span>Sign out</span>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </SidebarMenuItem>
+          {isLoggedIn ? (
+            <SidebarMenuItem>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <SidebarMenuButton>
+                    <User2 />
+                    {state === "expanded" && <span>Username</span>}
+                    {state === "expanded" && <ChevronUp className="ml-auto" />}
+                  </SidebarMenuButton>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  side="top"
+                  className="w-[--radix-popper-anchor-width]"
+                >
+                  <DropdownMenuItem>
+                    <span>Account</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem>
+                    <span>Billing</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={handleLogout}>
+                    <span>Sign out</span>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </SidebarMenuItem>
+          ) : (
+            <>
+              <SidebarMenuItem>
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <SidebarMenuButton>
+                      <LogIn />
+                      {state === "expanded" && <span>로그인</span>}
+                    </SidebarMenuButton>
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>로그인</DialogTitle>
+                    </DialogHeader>
+                    <LoginForm
+                      onSuccess={() => {
+                        setIsLoggedIn(true);
+                      }}
+                    />
+                  </DialogContent>
+                </Dialog>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <SidebarMenuButton>
+                      <UserPlus />
+                      {state === "expanded" && <span>회원가입</span>}
+                    </SidebarMenuButton>
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>회원가입</DialogTitle>
+                    </DialogHeader>
+                    <RegisterForm
+                      onSuccess={() => {
+                        setIsLoggedIn(true);
+                      }}
+                    />
+                  </DialogContent>
+                </Dialog>
+              </SidebarMenuItem>
+            </>
+          )}
         </SidebarMenu>
       </SidebarFooter>
     </Sidebar>
-  )
+  );
 }

--- a/front/src/components/ui/sonner.tsx
+++ b/front/src/components/ui/sonner.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }


### PR DESCRIPTION
### 이슈
- #10 

---

### 요약

로그인 및 회원가입 페이지의 전반적인 UI/UX를 개선하고, 사용자 경험을 향상시키기 위한 기능들을 추가했습니다. 디자인 일관성을 확보하고, 폼의 가시성을 높였으며, 비동기 작업에 대한 피드백을 제공하고, 비밀번호 확인 기능을 추가했습니다.

### 변경 사항

* **`LoginForm.tsx` 및 `RegisterForm.tsx` 디자인 레이아웃 통일 및 글자 크기 조정:**

  * 기존 `app-sidebar.tsx` 및 `start-new-topic-form.tsx`의 블랙앤 화이트 테마를 기반으로 폼 디자인을 통일했습니다.
  * 폼 내의 라벨, 입력 필드, 버튼 등의 글자 크기를 전반적으로 키워 가독성을 높였습니다.
  * 폼 컨테이너의 최대 너비를 `max-w-md`에서 `max-w-4xl`로 확장하여 폼의 가로 길이를 늘렸습니다.

* **`RegisterForm.tsx` 기능 개선:**

  * 회원가입 버튼 클릭 시 `isLoading` 상태를 추가하여 로딩 스피너를 표시하고 버튼을 비활성화했습니다.
  * 회원가입 성공/실패 시 `sonner` 라이브러리를 사용하여 토스트 알림 메시지를 표시하도록 변경했습니다. (성공 시 체크 아이콘 포함)
  * 회원가입 성공 시 콘솔 로그 및 `alert` 대신 `sonner` 알림 후 `/login` 페이지로 자동 이동하도록 설정했습니다.
  * 비밀번호 확인 필드(`passwordCheck`)를 추가하고, `password`와 `passwordCheck`가 일치하는지 유효성 검사를 수행하도록 했습니다.
  * 비밀번호가 일치하지 않거나 유효성 검사에 실패할 경우 회원가입 버튼을 비활성화하고 오류 메시지를 표시합니다.

* **`LoginForm.tsx` 기능 개선:**

  * 로그인 버튼 클릭 시 `isLoading` 상태를 추가하여 로딩 스피너를 표시하고 버튼을 비활성화했습니다.
  * 로그인 성공/실패 시 `sonner` 라이브러리를 사용하여 토스트 알림 메시지를 표시하도록 변경했습니다.
  * 로그인 성공 시 콘솔 로그 및 `alert` 대신 `sonner` 알림 후 루트 페이지(`/`)로 자동 이동하도록 설정했습니다.

* **`front/src/app/layout.tsx`에 `sonner` `Toaster` 컴포넌트 추가:**

  * `sonner` 토스트 알림이 전역적으로 작동하도록 `RootLayout`에 `<Toaster />` 컴포넌트를 추가했습니다.

* **`front/src/app/login/page.tsx` 및 `front/src/app/register/page.tsx`에 헤더 바 추가:**

  * 로그인 및 회원가입 페이지 상단에 "ChatGraph" 로고가 포함된 헤더 바를 추가했습니다.
  * 헤더 바의 배경색은 흰색, 글자색은 검은색으로 설정하고 하단에 얇은 회색 테두리를 추가했습니다.
  * "ChatGraph" 로고 클릭 시 루트 디렉토리(`/`)로 이동하도록 `Link` 컴포넌트를 적용했습니다.

### 추가 참고 사항

* `sonner` 라이브러리 설치 중 `react` 버전 충돌이 발생할 수 있습니다. 만약 `sonner`가 제대로 설치되지 않았다면, 다음 명령 중 하나를 사용하여 수동으로 설치해야 합니다:

  ```
  npm install sonner --force
  ```

  또는

  ```
  npm install sonner --legacy-peer-deps
  ```

---

