### PR TITLE
[Feature] 답변 및 관련 질문에 마크다운 렌더링 적용

### DIFF
--- a/front/src/components/enhanced-breadcrumb-focus-view/sub-question-list.tsx
+++ b/front/src/components/enhanced-breadcrumb-focus-view/sub-question-list.tsx
@@ -11,6 +11,7 @@ import {
   ChevronUp,
 } from "lucide-react";
 import { ViewData } from "@/lib/data-transformer"; // ViewData 임포트
+import ReactMarkdown from "react-markdown";
 
 interface SubQuestionListProps {
   questions: ViewData[]; // 자식 질문 목록
@@ -80,9 +81,9 @@ export const SubQuestionList = ({
                     </h4>
                   </div>
                   {expanded[child.id] && (
-                    <p className="text-sm text-gray-600 mb-3 pl-10">
-                      {child.answerText}
-                    </p> // 답변 들여쓰기
+                    <div className="text-sm text-gray-600 mb-3 pl-10">
+                      <ReactMarkdown>{child.answerText}</ReactMarkdown>
+                    </div> // 답변 들여쓰기
                   )}
                   <div className="flex items-center gap-2 pl-10">
                     {child.children.length > 0 && (

--- a/front/src/components/message-bubble.tsx
+++ b/front/src/components/message-bubble.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import ReactMarkdown from "react-markdown";
 
 interface MessageBubbleProps {
   questionText?: string;
@@ -38,7 +39,9 @@ export function MessageBubble({
           <div className="font-medium text-gray-900">{questionText}</div>
         )}
         {isAnswerVisible && answer && (
-          <div className="text-gray-700 leading-relaxed">{answer}</div>
+          <div className="text-gray-700 leading-relaxed">
+            <ReactMarkdown>{answer}</ReactMarkdown>
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
개요

   - message-bubble.tsx 및 sub-question-list.tsx 컴포넌트에서 answerText를 렌더링할 때
     마크다운 형식이 적용되도록 수정했습니다.

  변경 사항

   - react-markdown 라이브러리를 사용하여 마크다운 파싱 기능을 추가했습니다.
   - 기존의 텍스트 렌더링 부분을 ReactMarkdown 컴포넌트로 교체하여 마크다운 콘텐츠를
     올바르게 표시하도록 했습니다.

  관련 이슈

   - #16