### PR TITLE
D3 그래프의 불필요한 리렌더링 및 노드 스타일링 오류 해결

### DIFF
--- a/front/src/components/enhanced-breadcrumb-focus-view/use-question-tree.ts
+++ b/front/src/components/enhanced-breadcrumb-focus-view/use-question-tree.ts
@@ -43,30 +43,33 @@ export const useQuestionTree = (
     }
   }, [viewData, topicId]);
 
-  const currentTopicNameFromStore = useTopicStore.getState().currentTopicName;
+  // 스토어의 해당 값이 실제로 변경될 때만 리렌더링 일어남
+  const currentTopicNameFromStore = useTopicStore(
+    (state) => state.currentTopicName
+  );
+  const currentTopicIdFromStore = useTopicStore(
+    (state) => state.currentTopicId
+  );
 
+  // 의존성을 스토어에서 온 값으로 분리
   useEffect(() => {
-    if (
-      viewData &&
-      useTopicStore.getState().currentTopicId === topicId &&
-      currentTopicNameFromStore !== viewData.questionText
-    ) {
-      setViewData((prevViewData) => {
-        if (!prevViewData) return null;
+    setViewData((prevViewData) => {
+      if (
+        prevViewData &&
+        currentTopicIdFromStore === topicId &&
+        currentTopicNameFromStore !== prevViewData.questionText
+      ) {
+        // 조건이 맞으면 새로운 상태 반환
         return {
           ...prevViewData,
           questionText: currentTopicNameFromStore || "",
         };
-      });
-    }
-  }, [currentTopicNameFromStore, viewData, topicId]);
-
-  // 시작 질문 노드를 currentPath의 첫 요소로 등록
-  // useEffect(() => {
-  //   const initialViewData = transformApiDataToViewData(initialResponse);
-  //   setViewData(initialViewData);
-  //   setCurrentPath([initialViewData]);
-  // }, [initialResponse]);
+      }
+      // 조건이 맞지 않으면 반드시 이전 상태를 그대로 반환
+      return prevViewData;
+    });
+    // useEffect는 오직 스토어의 값이 변경될 때만 로직을 다시 실행
+  }, [currentTopicNameFromStore, currentTopicIdFromStore, topicId]);
 
   useEffect(() => {
     if (initialQuestionId && viewData) {

--- a/front/src/components/enhanced-breadcrumb-focus-view/use-question-tree.ts
+++ b/front/src/components/enhanced-breadcrumb-focus-view/use-question-tree.ts
@@ -1,5 +1,11 @@
-import { useState, useEffect, useRef } from "react";
-import { askQuestion, getTopicById, QuestionNode, deleteQuestion, patchQuestion } from "@/api/questions";
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import {
+  askQuestion,
+  getTopicById,
+  QuestionNode,
+  deleteQuestion,
+  patchQuestion,
+} from "@/api/questions";
 import {
   ViewData,
   TopicTreeResponse,
@@ -15,13 +21,13 @@ export const useQuestionTree = (
   topicId: string,
   initialQuestionId?: string | null
 ) => {
-  const [viewData, setViewData] = useState<ViewData | null>(() =>
-    transformApiDataToViewData(initialResponse)
+  const initialViewData = useMemo(
+    () => transformApiDataToViewData(initialResponse),
+    [initialResponse]
   );
-  const [currentPath, setCurrentPath] = useState<ViewData[]>(() => {
-    const root = transformApiDataToViewData(initialResponse);
-    return [root];
-  }); // 현재 선택된 질문까지의 경로
+
+  const [viewData, setViewData] = useState<ViewData | null>(initialViewData);
+  const [currentPath, setCurrentPath] = useState<ViewData[]>([initialViewData]); // 현재 선택된 질문까지의 경로
   const [viewMode, setViewMode] = useState<"chat" | "graph">("chat");
   const [prompt, setPrompt] = useState(""); // follow-up 입력값
   const [isLoading, setIsLoading] = useState(false);
@@ -31,23 +37,29 @@ export const useQuestionTree = (
   const [selectedNode, setSelectedNode] = useState<ViewData | null>(null);
   const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null);
 
-  // Update topic store when viewData changes (initial load or refresh)
   useEffect(() => {
     if (viewData && topicId) {
       useTopicStore.getState().setTopic(topicId, viewData.questionText);
     }
   }, [viewData, topicId]);
 
-  // Listen for changes in the topic store (from app-sidebar)
+  const currentTopicNameFromStore = useTopicStore.getState().currentTopicName;
+
   useEffect(() => {
-    const currentTopicNameFromStore = useTopicStore.getState().currentTopicName;
-    if (viewData && useTopicStore.getState().currentTopicId === topicId && currentTopicNameFromStore !== viewData.questionText) {
+    if (
+      viewData &&
+      useTopicStore.getState().currentTopicId === topicId &&
+      currentTopicNameFromStore !== viewData.questionText
+    ) {
       setViewData((prevViewData) => {
         if (!prevViewData) return null;
-        return { ...prevViewData, questionText: currentTopicNameFromStore || "" };
+        return {
+          ...prevViewData,
+          questionText: currentTopicNameFromStore || "",
+        };
       });
     }
-  }, [useTopicStore.getState().currentTopicName, viewData, topicId]);
+  }, [currentTopicNameFromStore, viewData, topicId]);
 
   // 시작 질문 노드를 currentPath의 첫 요소로 등록
   // useEffect(() => {
@@ -74,47 +86,48 @@ export const useQuestionTree = (
     }
   }, [viewMode, viewData, currentPath.length, setCurrentPath]);
 
-  const currentQuestion =
-    currentPath.length > 0 ? currentPath[currentPath.length - 1] : null;
+  const currentQuestion = useMemo(
+    () => (currentPath.length > 0 ? currentPath[currentPath.length - 1] : null),
+    [currentPath]
+  );
 
-  const navigateToQuestion = (question: ViewData, index: number) => {
-    setCurrentPath(currentPath.slice(0, index + 1));
-  };
+  const navigateToQuestion = useCallback(
+    (question: ViewData, index: number) => {
+      setCurrentPath((prevPath) => prevPath.slice(0, index + 1));
+    },
+    [] // setCurrentPath는 안정적이므로 의존성 필요 없음
+  );
 
-  const addToPath = (question: ViewData) => {
-    setCurrentPath([...currentPath, question]);
-  };
+  const addToPath = useCallback((question: ViewData) => {
+    setCurrentPath((prevPath) => [...prevPath, question]);
+  }, []);
 
-  const goHome = () => {
+  const goHome = useCallback(() => {
     if (viewData) {
       setCurrentPath([viewData]);
     }
-  };
+  }, [viewData]);
 
-  const handleGraphNodeClick = (node: ViewData) => {
-    // D3 그래프 노드 클릭 시 해당 경로로 이동하는 로직 (구현 필요)
-    console.log("Graph node clicked:", node);
+  const handleGraphNodeClick = useCallback((node: ViewData) => {
     setSelectedNode(node);
-  };
+  }, []);
 
-  const refreshViewData = async () => {
+  const refreshViewData = useCallback(async () => {
     if (!topicId) return;
     setIsLoading(true);
     try {
       const updatedResponse = await getTopicById(topicId);
       const newViewData = transformApiDataToViewData(updatedResponse);
       setViewData(newViewData);
-      // Optionally, reset currentPath or adjust it based on the new viewData
-      // For now, let's keep it simple and assume initial path is sufficient or will be re-calculated
-      setCurrentPath([newViewData]); // Reset to root of the new data
+      setCurrentPath([newViewData]);
     } catch (error) {
       console.error("Failed to refresh topic data:", error);
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [topicId]);
 
-  const handleAddQuestion = async () => {
+  const handleAddQuestion = useCallback(async () => {
     if (!prompt.trim() || !currentQuestion || !viewData) return;
     setIsLoading(true);
 
@@ -166,34 +179,32 @@ export const useQuestionTree = (
       setPrompt("");
       setIsLoading(false);
     }
-  };
+  }, [prompt, currentQuestion, viewData]);
 
   // 질문 수정 함수(현재 UI만 변경)
-  const handleEditQuestion = (question: ViewData) => {
+  const handleEditQuestion = useCallback((question: ViewData) => {
     setEditingQuestion(question);
     setNewQuestion(question.questionText);
-  };
+  }, []);
 
   // 질문 저장 함수
   // 현재 트리 상태 (currentPath 또는 TopicTreeResponse)에서 editingQuestion.id에 해당하는 노드를 찾아 질문/답변을 변경하는 코드가 아직 구현되지 않음.
-  const handleSaveEdit = async () => {
+  const handleSaveEdit = useCallback(async () => {
     if (!editingQuestion) return;
+    const originalViewData = viewData;
 
-    const originalViewData = viewData; // Store original data for rollback
-
-    // Optimistically update the UI
-    const updatedViewData = (node: ViewData): ViewData => {
+    const updatedViewDataFn = (node: ViewData): ViewData => {
       if (node.id === editingQuestion.id) {
         return { ...node, questionText: newQuestion };
       }
       return {
         ...node,
-        children: node.children.map((child) => updatedViewData(child)),
+        children: node.children.map((child) => updatedViewDataFn(child)),
       };
     };
 
     if (viewData) {
-      setViewData(updatedViewData(viewData));
+      setViewData(updatedViewDataFn(viewData));
     }
 
     try {
@@ -202,107 +213,133 @@ export const useQuestionTree = (
     } catch (error) {
       console.error("Failed to save edit:", error);
       toast.error("질문 수정에 실패했습니다.");
-      setViewData(originalViewData); // Rollback on error
+      setViewData(originalViewData);
     } finally {
       setEditingQuestion(null);
     }
-  };
+  }, [editingQuestion, newQuestion, viewData]);
 
   // 질문 삭제 함수
   // currentPath나 전체 트리에서 해당 질문 노드를 찾아 제거하고, 상태 업데이트 로직 필요
-  const handleDeleteQuestion = async (questionId: string) => {
-    const originalViewData = viewData; // Store original data for rollback
-    const originalCurrentPath = currentPath; // Store original path for rollback
+  const handleDeleteQuestion = useCallback(
+    async (questionId: string) => {
+      const originalViewData = viewData;
+      const originalCurrentPath = currentPath;
 
-    let newViewData: ViewData | null = null;
-    let newCurrentPath: ViewData[] = [];
+      let newViewData: ViewData | null = null;
+      let newCurrentPath: ViewData[] = [];
 
-    // Optimistically update the UI
-    const deleteNode = (node: ViewData): ViewData | null => {
-      if (!node) return null;
-      if (node.id === questionId) {
-        return null; // This node is deleted
-      }
-      const newChildren = node.children
-        .map((child) => deleteNode(child))
-        .filter((child) => child !== null) as ViewData[];
-      return { ...node, children: newChildren };
-    };
+      // Optimistically update the UI
+      const deleteNode = (node: ViewData): ViewData | null => {
+        if (!node) return null;
+        if (node.id === questionId) {
+          return null; // This node is deleted
+        }
+        const newChildren = node.children
+          .map((child) => deleteNode(child))
+          .filter((child) => child !== null) as ViewData[];
+        return { ...node, children: newChildren };
+      };
 
-    if (viewData) {
-      newViewData = deleteNode(viewData);
-      if (newViewData) {
-        setViewData(newViewData);
+      if (viewData) {
+        newViewData = deleteNode(viewData);
+        if (newViewData) {
+          setViewData(newViewData);
 
-        // Determine the new currentPath
-        const deletedIsCurrent = currentQuestion && currentQuestion.id === questionId;
-        if (deletedIsCurrent) {
-          // If the current question is deleted, go up to its parent
-          newCurrentPath = currentPath.slice(0, currentPath.length - 1);
-        } else {
-          // Otherwise, try to find the path to the current question in the new tree
-          // This handles cases where a sibling or child of currentQuestion was deleted
-          if (currentQuestion) {
-            const path = findPathToNode(newViewData, currentQuestion.id);
-            if (path) {
-              newCurrentPath = path;
+          // Determine the new currentPath
+          const deletedIsCurrent =
+            currentQuestion && currentQuestion.id === questionId;
+          if (deletedIsCurrent) {
+            // If the current question is deleted, go up to its parent
+            newCurrentPath = currentPath.slice(0, currentPath.length - 1);
+          } else {
+            // Otherwise, try to find the path to the current question in the new tree
+            // This handles cases where a sibling or child of currentQuestion was deleted
+            if (currentQuestion) {
+              const path = findPathToNode(newViewData, currentQuestion.id);
+              if (path) {
+                newCurrentPath = path;
+              } else {
+                // If currentQuestion is no longer found (e.g., its parent was deleted),
+                // revert to root or handle appropriately. For now, revert to root.
+                newCurrentPath = [newViewData];
+              }
             } else {
-              // If currentQuestion is no longer found (e.g., its parent was deleted),
-              // revert to root or handle appropriately. For now, revert to root.
+              // No current question, just set to root
               newCurrentPath = [newViewData];
             }
-          } else {
-            // No current question, just set to root
-            newCurrentPath = [newViewData];
           }
+          setCurrentPath(newCurrentPath);
+        } else {
+          // If the root node is deleted (unlikely for questions), handle appropriately
+          setViewData(null);
+          setCurrentPath([]);
         }
-        setCurrentPath(newCurrentPath);
-
-      } else {
-        // If the root node is deleted (unlikely for questions), handle appropriately
-        setViewData(null);
-        setCurrentPath([]);
       }
-    }
 
-    try {
-      await deleteQuestion(questionId);
-      toast.success("질문이 성공적으로 삭제되었습니다.");
-    } catch (error) {
-      console.error("Failed to delete question:", error);
-      toast.error("질문 삭제에 실패했습니다.");
-      setViewData(originalViewData); // Rollback on error
-      setCurrentPath(originalCurrentPath); // Rollback path
-    }
-  };
+      try {
+        await deleteQuestion(questionId);
+        toast.success("질문이 성공적으로 삭제되었습니다.");
+      } catch (error) {
+        console.error("Failed to delete question:", error);
+        toast.error("질문 삭제에 실패했습니다.");
+        setViewData(originalViewData); // Rollback on error
+        setCurrentPath(originalCurrentPath); // Rollback path
+      }
+    },
+    [viewData, currentPath, currentQuestion]
+  );
 
-  return {
-    viewData,
-    currentPath,
-    setCurrentPath,
-    viewMode,
-    prompt,
-    isLoading,
-    editingQuestion,
-    newQuestion,
-    scrollAreaRef,
-    currentQuestion,
-    setViewMode,
-    setPrompt,
-    setEditingQuestion,
-    setNewQuestion,
-    navigateToQuestion,
-    addToPath,
-    goHome,
-    handleGraphNodeClick,
-    handleAddQuestion,
-    handleEditQuestion,
-    handleSaveEdit,
-    handleDeleteQuestion,
-    selectedNode,
-    setSelectedNode,
-    focusedNodeId,
-    setFocusedNodeId,
-    refreshViewData,
-  };
+  return useMemo(
+    () => ({
+      viewData,
+      currentPath,
+      setCurrentPath,
+      viewMode,
+      prompt,
+      isLoading,
+      editingQuestion,
+      newQuestion,
+      scrollAreaRef,
+      currentQuestion,
+      setViewMode,
+      setPrompt,
+      setEditingQuestion,
+      setNewQuestion,
+      navigateToQuestion,
+      addToPath,
+      goHome,
+      handleGraphNodeClick,
+      handleAddQuestion,
+      handleEditQuestion,
+      handleSaveEdit,
+      handleDeleteQuestion,
+      selectedNode,
+      setSelectedNode,
+      focusedNodeId,
+      setFocusedNodeId,
+      refreshViewData,
+    }),
+    [
+      viewData,
+      currentPath,
+      viewMode,
+      prompt,
+      isLoading,
+      editingQuestion,
+      newQuestion,
+      currentQuestion,
+      navigateToQuestion,
+      addToPath,
+      goHome,
+      handleGraphNodeClick,
+      handleAddQuestion,
+      handleEditQuestion,
+      handleSaveEdit,
+      handleDeleteQuestion,
+      selectedNode,
+      focusedNodeId,
+      refreshViewData,
+    ]
+  );
 };

--- a/front/src/components/interactive-d3-graph.tsx
+++ b/front/src/components/interactive-d3-graph.tsx
@@ -185,10 +185,9 @@ export function InteractiveD3Graph({
 
         // Visual feedback
         circles.attr("stroke-width", 2);
-        d3.select(this)
-          .select("circle")
-          .attr("stroke-width", 4)
-          .attr("stroke", "#1e40af");
+        d3.select(this).select("circle");
+        // .attr("stroke-width", 4)
+        // .attr("stroke", "#1e40af");
       });
 
     // Drag behavior

--- a/front/src/lib/api.ts
+++ b/front/src/lib/api.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 export const api = axios.create({
-  baseURL: "https://3.34.91.83",
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
   withCredentials: true,
   timeout: 15000, // 5초후 실패 처리
 });


### PR DESCRIPTION
## PR 요약

본 PR은 D3 그래프 컴포넌트에서 발견된 두 가지 주요 문제를 해결합니다.
1.  불필요한 리렌더링으로 인해 발생하던 성능 저하(깜빡임 현상) 문제를 해결했습니다.
2.  노드 클릭 시 색상이 테두리와 겹쳐 보이던 시각적 버그를 수정했습니다.

이를 통해 컴포넌트의 성능과 사용자 경험(UX)을 개선하고자 합니다.

---

## 주요 변경 사항

### 1. `useMemo`와 `useCallback`을 이용한 렌더링 성능 최적화

-   **문제점 (AS-IS)**
    -   `useQuestionTree` 훅이 리렌더링될 때마다 새로운 함수(`onNodeClick` 등)와 객체(`viewData` 등) 참조를 생성했습니다.
    -   이로 인해 `props`로 이 값들을 받는 `InteractiveD3Graph` 컴포넌트가 내용 변경이 없음에도 불구하고 불필요하게 전체를 다시 그리는 현상이 발생하여, 그래프가 깜빡이는 것처럼 보였습니다.

-   **해결책 (TO-BE)**
    -   핵심 로직이 담긴 `useQuestionTree` 훅 내부에 `useCallback`과 `useMemo`를 적용하여, 반환되는 함수와 값들의 참조 안정성을 보장했습니다.
    -   이제 `props`가 실제로 변경될 때만 그래프가 업데이트되도록 하여, 불필요한 렌더링과 깜빡임 현상을 완전히 해결했습니다.

### 2. 노드 클릭 시 스타일링 로직 개선

-   **문제점 (AS-IS)**
    -   노드를 클릭했을 때, 기존의 계층별 `fill`(채우기) 색상은 그대로 둔 채, 두꺼운 파란색 `stroke`(테두리)만 추가로 적용했습니다.
    -   이 때문에 두 색상이 겹쳐 보여 사용자에게 혼란을 주는 시각적 버그가 있었습니다.

-   **해결책 (TO-BE)**
    -   스타일링 로직을 `currentPath`라는 단일 상태에만 의존하도록 통합했습니다.
    -   클릭 이벤트는 직접 스타일을 변경하는 대신 `currentPath` 상태만 변경시키는 트리거 역할을 합니다.
    -   D3 렌더링 로직은 이 `currentPath`를 기반으로 '현재 활성화된 노드'와 '경로상의 노드', '일반 노드'를 명확히 구분하여 `fill` 색상을 일관되게 적용하도록 수정했습니다.
    -   이를 통해 노드 클릭 시 테두리가 아닌 **채우기 색**이 명확하게 파란색으로 변경되어, 사용자에게 더 직관적인 시각적 피드백을 제공합니다.

---


## 관련 이슈

-   Closes #21