### PR TITLE
 fix: 비로그인 시 주요 기능 버튼 비활성화 및 안내 툴팁 추가

### DIFF
--- a/front/src/components/app-sidebar.tsx
+++ b/front/src/components/app-sidebar.tsx
@@ -238,14 +238,33 @@ interface SearchResultNode extends QuestionNode {
       <SidebarContent className="p-2">
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton
-              tooltip="검색"
-              onClick={() => setIsSearchVisible(!isSearchVisible)}
-            >
-              <Search />
-              <span>검색</span>
-            </SidebarMenuButton>
-            {isSearchVisible && state === "expanded" && (
+            {isLoggedIn ? (
+              <SidebarMenuButton
+                tooltip="검색"
+                onClick={() => setIsSearchVisible(!isSearchVisible)}
+              >
+                <Search />
+                <span>검색</span>
+              </SidebarMenuButton>
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="w-full">
+                    <SidebarMenuButton
+                      disabled
+                      className="w-full cursor-not-allowed"
+                    >
+                      <Search />
+                      <span>검색</span>
+                    </SidebarMenuButton>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>로그인이 필요합니다</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
+            {isLoggedIn && isSearchVisible && state === "expanded" && (
               <div className="mt-2">
                 <SidebarInput
                   placeholder="검색"

--- a/front/src/components/start-new-topic-form.tsx
+++ b/front/src/components/start-new-topic-form.tsx
@@ -1,17 +1,32 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { ArrowUp } from "lucide-react";
 import { askQuestion } from "@/api/questions";
 import Image from "next/image";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export function StartNewTopicForm() {
   const [prompt, setPrompt] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [isLogin,setIsLogin] = useState(false);
   const router = useRouter();
+  
+  // 컴포넌트가 마운트될 때 로그인 상태를 확인합니다.
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (token) {
+      setIsLogin(true);
+    }
+  }, []); // 빈 배열을 전달하여 한 번만 실행되도록 합니다.
+
 
   const handleStartNewTopic = async () => {
     if (!prompt.trim()) return;
@@ -58,18 +73,33 @@ export function StartNewTopicForm() {
                 disabled={isLoading}
               />
             </div>
-            <Button
-              onClick={handleStartNewTopic}
-              disabled={!prompt.trim() || isLoading}
-              size="lg"
-              className="flex-shrink-0"
-            >
-              {isLoading ? (
-                <div className="h-5 w-5 animate-spin rounded-full border-2 border-gray-300" />
-              ) : (
-                <ArrowUp className="h-5 w-5" />
-              )}
-            </Button>
+            {isLogin ? (
+              <Button
+                onClick={handleStartNewTopic}
+                disabled={!prompt.trim() || isLoading}
+                size="lg"
+                className="flex-shrink-0"
+              >
+                {isLoading ? (
+                  <div className="h-5 w-5 animate-spin rounded-full border-2 border-gray-300" />
+                ) : (
+                  <ArrowUp className="h-5 w-5" />
+                )}
+              </Button>
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex-shrink-0">
+                    <Button disabled size="lg" className="cursor-not-allowed">
+                      <ArrowUp className="h-5 w-5" />
+                    </Button>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>로그인이 필요합니다</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
           </div>
         </div>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "capstone-front",
+  "name": "chatGraph-FE",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION

### 작업 내용

  로그인하지 않은 사용자가 핵심 기능을 시도할 때 혼란을 겪지 않도록 UI를 개선했습니다. 주요
  기능 버튼을 비활성화하고, Tooltip을 이용해 사용자에게 로그인 필요성을 명확하게 안내합니다.
### 주요 변경 사항

   1. 검색 버튼 비활성화 (`app-sidebar.tsx`)
       - 로그인하지 않은 경우, 사이드바의 검색 버튼이 비활성화됩니다.
       - 비활성화된 버튼에 마우스를 올리면 "로그인이 필요합니다"라는 툴팁이 표시됩니다.

   2. 새 토픽 시작 버튼 비활성화 (`start-new-topic-form.tsx`)
       - 로그인하지 않은 경우, 메인 화면의 새 토픽 시작(질문 전송) 버튼이 비활성화됩니다.
       - 마찬가지로 "로그인이 필요합니다"라는 툴팁을 추가하여 사용자에게 명확한 피드백을
         제공합니다.

  ### 기술적 세부사항

   - 각 컴포넌트의 로그인 상태(isLoggedIn, isLogin)를 확인하여 버튼의 disabled 속성을
     제어합니다.
   - shadcn/ui의 Tooltip 컴포넌트를 사용하여 사용자에게 필요한 정보를 안내합니다.

  관련 이슈

   - #29