### PR TITLE
feat: 토픽 선택 모달 추가 및 토픽 이동

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
-        "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.14",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-scroll-area": "^1.2.9",
@@ -20,6 +20,7 @@
         "axios": "^1.10.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "d3": "^7.9.0",
         "lucide-react": "^0.507.0",
         "next": "15.2.2",
@@ -3752,6 +3753,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/color": {

--- a/front/package.json
+++ b/front/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.15",
-    "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.14",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-scroll-area": "^1.2.9",
@@ -21,6 +21,7 @@
     "axios": "^1.10.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "d3": "^7.9.0",
     "lucide-react": "^0.507.0",
     "next": "15.2.2",

--- a/front/src/components/enhanced-breadcrumb-focus-view/TopicSelectorModal.tsx
+++ b/front/src/components/enhanced-breadcrumb-focus-view/TopicSelectorModal.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { InteractiveD3Graph } from "../interactive-d3-graph"; // D3 그래프 재사용
+// 토픽 목록 API 경로
+import { getTopicById } from "@/api/questions";
+import { getTopicsHistory } from "@/api/topics-history";
+import { ViewData, transformApiDataToViewData } from "@/lib/data-transformer";
+import { useQuestionTreeContext } from "./QuestionTreeContext";
+
+// API 응답 타입
+interface TopicHistoryItem {
+  topicId: string;
+  topicName: string;
+  createdAt: string;
+}
+
+interface TopicSelectorModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  currentNodeToMove: ViewData | null;
+  onNodeSelected: (
+    targetTopic: TopicHistoryItem,
+    targetParentNode: { id: string; name: string }
+  ) => void;
+}
+
+export function TopicSelectorModal({
+  isOpen,
+  onClose,
+  onNodeSelected,
+}: TopicSelectorModalProps) {
+  const { viewData } = useQuestionTreeContext();
+
+  const currentTopicId = viewData ? viewData.id : null;
+
+  const [step, setStep] = useState<"SELECT_TOPIC" | "SELECT_NODE">(
+    "SELECT_TOPIC"
+  );
+
+  // 토픽 목록
+  const [topics, setTopics] = useState<TopicHistoryItem[]>([]);
+  const [selectedTopic, setSelectedTopic] = useState<TopicHistoryItem | null>(
+    null
+  );
+
+  // 선택한 토픽의 그래프 데이터
+  const [targetTopicGraph, setTargetTopicGraph] = useState<ViewData | null>(
+    null
+  );
+  const [isLoading, setIsLoading] = useState(false);
+
+  // 모달이 열릴 때 토픽 목록(history)을 불러옴
+  useEffect(() => {
+    if (isOpen) {
+      // 모달이 열릴 때마다 초기화
+      setStep("SELECT_TOPIC");
+      setSelectedTopic(null);
+      setTargetTopicGraph(null);
+
+      const fetchTopics = async () => {
+        setIsLoading(true);
+        try {
+          // 'getTopicsHistory' API가 토픽 목록을 반환
+          const topicList = await getTopicsHistory();
+          setTopics(topicList);
+        } catch (error) {
+          console.error("토픽 목록을 불러오는 데 실패했습니다.", error);
+        }
+        setIsLoading(false);
+      };
+      fetchTopics();
+    }
+  }, [isOpen]);
+
+  // 사용자가 토픽을 선택했을 때 해당 토픽의 그래프 데이터를 불러옴
+  const handleTopicSelect = async (topic: TopicHistoryItem) => {
+    setSelectedTopic(topic);
+    setIsLoading(true);
+    try {
+      // 'getTopicById' API가 해당 토픽의 전체 트리를 반환
+      const topicTree = await getTopicById(topic.topicId);
+      setTargetTopicGraph(transformApiDataToViewData(topicTree));
+      setStep("SELECT_NODE");
+    } catch (error) {
+      console.error("토픽 그래프를 불러오는 데 실패했습니다.", error);
+    }
+    setIsLoading(false);
+  };
+
+  // 미니 그래프에서 부모 노드를 선택했을 때
+  const handleNodeSelect = (node: ViewData) => {
+    if (!selectedTopic) return;
+    // 최종 선택 완료. 부모에게 알림
+    onNodeSelected(selectedTopic, { id: node.id, name: node.questionText });
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-5xl h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>이동할 토픽 및 노드 선택</DialogTitle>
+          <DialogDescription>
+            {step === "SELECT_TOPIC"
+              ? "이동할 대상 토픽을 선택하세요."
+              : `[${selectedTopic?.topicName}] 토픽에서 새로 연결할 부모 노드를 클릭하세요.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading && <div>로딩 중...</div>}
+
+        {/* 토픽 목록 보여주기 */}
+        {!isLoading && step === "SELECT_TOPIC" && (
+          <ScrollArea className="flex-1">
+            <Command>
+              <CommandInput placeholder="토픽 검색..." />
+              <CommandList>
+                <CommandEmpty>검색 결과가 없습니다.</CommandEmpty>
+                <CommandGroup>
+                  {topics.map((topic) => (
+                    <CommandItem
+                      key={topic.topicId}
+                      // 현재 토픽은 비활성화
+                      disabled={topic.topicId === currentTopicId}
+                      onSelect={() => handleTopicSelect(topic)}
+                    >
+                      {topic.topicName}
+                      {topic.topicId === currentTopicId && " (현재 토픽)"}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </ScrollArea>
+        )}
+
+        {/* 선택한 토픽의 그래프 보여주기 */}
+        {!isLoading && step === "SELECT_NODE" && targetTopicGraph && (
+          <div className="flex-1 border rounded-md overflow-hidden ">
+            {/* D3 그래프 컴포넌트 재사용 */}
+            <InteractiveD3Graph
+              data={targetTopicGraph}
+              onNodeClick={handleNodeSelect} // 클릭 시 handleNodeSelect 호출
+            />
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/src/components/enhanced-breadcrumb-focus-view/focus-view-header.tsx
+++ b/front/src/components/enhanced-breadcrumb-focus-view/focus-view-header.tsx
@@ -12,6 +12,7 @@ export const FocusViewHeader = () => {
     modifyMode,
     startModifyMode,
     cancelModifyMode,
+    moveToOtherMode,
   } = useQuestionTreeContext();
 
   if (viewMode === "graph") {
@@ -26,11 +27,20 @@ export const FocusViewHeader = () => {
         </div>
         <div className="flex items-center gap-2">
           {modifyMode === "IDLE" ? (
-            // 3a. 기본 모드일 때는 "수정" 버튼
-            <Button variant="outline" onClick={startModifyMode}>
-              <Edit className="h-4 w-4 mr-2" />
-              관계 수정
-            </Button>
+            <>
+              <Button variant="outline">
+                <Edit className="h-4 w-4 mr-2" />새 토픽으로 분리
+              </Button>
+              <Button variant="outline" onClick={moveToOtherMode}>
+                <Edit className="h-4 w-4 mr-2" />
+                다른 토픽으로 이동
+              </Button>
+              {/* 3a. 기본 모드일 때는 "수정" 버튼 */}
+              <Button variant="outline" onClick={startModifyMode}>
+                <Edit className="h-4 w-4 mr-2" />
+                관계 수정
+              </Button>
+            </>
           ) : (
             // 3b. 수정 모드일 때는 "취소" 버튼
             <Button variant="destructive" onClick={cancelModifyMode}>

--- a/front/src/components/enhanced-breadcrumb-focus-view/index.tsx
+++ b/front/src/components/enhanced-breadcrumb-focus-view/index.tsx
@@ -6,6 +6,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { MessageBubble } from "@/components/message-bubble";
 import { InteractiveD3Graph } from "@/components/interactive-d3-graph";
 import { TopicTreeResponse } from "@/lib/data-transformer";
+import { TopicSelectorModal } from "./TopicSelectorModal";
 
 import {
   AlertDialogAction,
@@ -33,14 +34,14 @@ import { AlertDialog } from "@radix-ui/react-alert-dialog";
 
 interface EnhancedBreadcrumbFocusViewProps {
   initialResponse: TopicTreeResponse;
-  initialQuestionId?: string | null; // Make it optional and nullable
+  initialQuestionId?: string | null;
 }
 
 export function EnhancedBreadcrumbFocusView({
   initialResponse,
   initialQuestionId,
 }: EnhancedBreadcrumbFocusViewProps) {
-  const topicId = initialResponse.topic; // Extract topicId here
+  const topicId = initialResponse.topic;
   return (
     <QuestionTreeProvider
       initialResponse={initialResponse}
@@ -52,8 +53,7 @@ export function EnhancedBreadcrumbFocusView({
   );
 }
 
-function EnhancedBreadcrumbFocusViewContent({}: // initialResponse,
-EnhancedBreadcrumbFocusViewProps) {
+function EnhancedBreadcrumbFocusViewContent({}: EnhancedBreadcrumbFocusViewProps) {
   const {
     viewData,
     currentPath,
@@ -79,6 +79,12 @@ EnhancedBreadcrumbFocusViewProps) {
     confirmReparenting,
     cancelModifyMode,
     reparentRequest,
+    nodeToMove,
+    isTopicSelectorOpen,
+    setIsTopicSelectorOpen,
+    moveToTopicRequest,
+    setMoveTopicRequest,
+    confirmMoveToOtherTopic,
   } = useQuestionTreeContext();
 
   const [isMainAnswerVisible, setIsMainAnswerVisible] = useState(true);
@@ -121,7 +127,7 @@ EnhancedBreadcrumbFocusViewProps) {
         <FocusViewHeader />
         <div className="flex-1 p-4">
           <InteractiveD3Graph
-            data={viewData} // Use viewData directly
+            data={viewData}
             onNodeClick={handleGraphNodeClick}
           />
           <QuestionDetailModal
@@ -168,6 +174,59 @@ EnhancedBreadcrumbFocusViewProps) {
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
+
+          {/* 토픽 선택 모달 렌더링 */}
+          <TopicSelectorModal
+            isOpen={isTopicSelectorOpen}
+            onClose={cancelModifyMode}
+            currentNodeToMove={nodeToMove}
+            onNodeSelected={(targetTopic, targetParentNode) => {
+              // 토픽 선택 모달이 성공적으로 부모 노드를 선택했을때
+              setIsTopicSelectorOpen(false); // 토픽 선택 모달 닫기
+              setMoveTopicRequest({
+                // 최종 확인 모달 띄우기
+                movedNode: nodeToMove!,
+                targetTopic: {
+                  id: targetTopic.topicId,
+                  name: targetTopic.topicName,
+                },
+                targetParentId: targetParentNode.id,
+                targetParentNode: {
+                  id: targetParentNode.id,
+                  name: targetParentNode.name,
+                },
+              });
+            }}
+          />
+
+          {/* 다른 토픽으로 이동 최종 확인 모달 */}
+          <AlertDialog
+            open={!!moveToTopicRequest}
+            onOpenChange={(open) => {
+              if (!open) setMoveTopicRequest(null);
+            }}
+          >
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>다른 토픽으로 이동 확인</AlertDialogTitle>
+                <AlertDialogDescription>
+                  <b>{moveToTopicRequest?.movedNode.questionText}</b> 질문
+                  줄기를
+                  <br />
+                  <b>{moveToTopicRequest?.targetParentNode.name}</b> 하위로
+                  이동하시겠습니까?
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel onClick={() => setMoveTopicRequest(null)}>
+                  취소
+                </AlertDialogCancel>
+                <AlertDialogAction onClick={confirmMoveToOtherTopic}>
+                  이동
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </div>
       </div>
     );
@@ -187,7 +246,7 @@ EnhancedBreadcrumbFocusViewProps) {
               <MessageBubble
                 questionText={currentQuestion.questionText}
                 answer={currentQuestion.answerText}
-                isUser={true} // Assuming the focused question is always by the user
+                isUser={true}
                 isToggleable={true}
                 isAnswerVisible={isMainAnswerVisible}
                 onToggleAnswer={() =>
@@ -209,7 +268,7 @@ EnhancedBreadcrumbFocusViewProps) {
           <div className="max-w-4xl mx-auto">
             {currentQuestion.children.length > 0 && (
               <SubQuestionList
-                key={currentQuestion.id} // Add key prop here
+                key={currentQuestion.id}
                 questions={currentQuestion.children}
                 addToPath={addToPath}
                 onSave={handleSaveInPlaceEdit}

--- a/front/src/components/enhanced-breadcrumb-focus-view/use-question-tree.ts
+++ b/front/src/components/enhanced-breadcrumb-focus-view/use-question-tree.ts
@@ -45,12 +45,24 @@ export const useQuestionTree = (
   );
 
   // 수정 모드가 가질 수 있는 3가지 상태
-  type ModifyMode = "IDLE" | "SELECT_CHILD" | "SELECT_PARENT";
+  type ModifyMode =
+    | "IDLE"
+    | "SELECT_CHILD"
+    | "SELECT_PARENT"
+    | "SELECT_NODE_TO_MOVE_OTHER";
 
   // '부모 변경 확인' 모달에 필요한 데이터 타입 정의
   interface ReparentRequest {
     movedNode: ViewData;
     newParentNode: ViewData;
+  }
+
+  // 다른 토픽으로 이동 최종 확인 모달에 필요한 데이터 타입
+  interface MoveToTopicRequest {
+    movedNode: ViewData;
+    targetTopic: { id: string; name: string };
+    targetParentId: string;
+    targetParentNode: { id: string; name: string };
   }
 
   const [viewData, setViewData] = useState<ViewData | null>(initialViewData);
@@ -70,6 +82,12 @@ export const useQuestionTree = (
   // "부모 변경 확인" 모달을 위한 상태
   const [reparentRequest, setReparentRequest] =
     useState<ReparentRequest | null>(null);
+  // 다른 토픽으로 이동 관련 상태
+  const [isTopicSelectorOpen, setIsTopicSelectorOpen] = useState(false);
+  const [moveToTopicRequest, setMoveTopicRequest] =
+    useState<MoveToTopicRequest | null>(null);
+
+  // const router = useRouter();
 
   useEffect(() => {
     if (viewData && topicId) {
@@ -207,6 +225,15 @@ export const useQuestionTree = (
             newParentNode: newParentNode,
           });
           break;
+
+        case "SELECT_NODE_TO_MOVE_OTHER":
+          setNodeToMove(clickedNode); // 이동할 노드 저장
+          setIsTopicSelectorOpen(true); // '토픽 선택 모달' 띄우기
+          setModifyMode("IDLE"); // 임시로 IDLE로 돌리고, "토픽 선택 모달" 띄움
+          toast.info(
+            `'${clickedNode.questionText}' 선택됨. 이동할 토픽을 선택하세요.`
+          );
+          break;
       }
     },
     [
@@ -219,6 +246,13 @@ export const useQuestionTree = (
       setReparentRequest,
     ]
   );
+
+  // 다른 토픽으로 이동 버튼을 눌렀을 때 실행할 함수
+  const moveToOtherMode = useCallback(() => {
+    // 모드 설정
+    setModifyMode("SELECT_NODE_TO_MOVE_OTHER");
+    toast.info("다른 토픽으로 이동할 질문을 선택하세요.");
+  }, []);
 
   // 수정 버튼을 눌렀을 때 실행할 함수
   const startModifyMode = useCallback(() => {
@@ -233,6 +267,8 @@ export const useQuestionTree = (
     setModifyMode("IDLE"); // 다시 기본값으로 변경
     setNodeToMove(null); // 선택했던 노드가 있으면 초기화
     setReparentRequest(null); // 모달 닫기
+    setIsTopicSelectorOpen(false);
+    setMoveTopicRequest(null);
     toast.dismiss(); // 띄워둔 토스트 알림 닫기
   }, []);
 
@@ -289,6 +325,38 @@ export const useQuestionTree = (
       cancelModifyMode();
     }
   }, [reparentRequest, refreshViewData, cancelModifyMode]);
+
+  // "다른 토픽 이동"을 최종 실행하는 함수(모달의 '이동' 버튼)
+  const confirmMoveToOtherTopic = useCallback(async () => {
+    if (!moveToTopicRequest) return;
+
+    const { movedNode, targetParentId } = moveToTopicRequest;
+
+    toast.loading("다른 토픽으로 노드를 이동하는 중...");
+
+    try {
+      // 복사할 ID 전체 수집
+      const allIdsToCopy = getAllIdsFromNode(movedNode);
+
+      // 복사
+      await copyQuestions({
+        sourceQuestionIds: allIdsToCopy,
+        targetParentId: targetParentId,
+      });
+
+      // 원본 삭제
+      await deleteQuestionBatch(allIdsToCopy);
+
+      // 갱신
+      await refreshViewData(); // 현재 토픽 갱신
+      toast.success("노드 이동이 완료되었습니다.");
+    } catch (error) {
+      console.error("다른 토픽으로 이동 실패:", error);
+      toast.error("노드 이동에 실패했습니다.");
+    } finally {
+      cancelModifyMode();
+    }
+  }, [moveToTopicRequest, refreshViewData, cancelModifyMode]);
 
   const handleAddQuestion = useCallback(async () => {
     if (!prompt.trim() || !currentQuestion || !viewData) return;
@@ -577,6 +645,13 @@ export const useQuestionTree = (
       cancelModifyMode,
       reparentRequest,
       confirmReparenting,
+      moveToOtherMode,
+      confirmMoveToOtherTopic,
+      nodeToMove,
+      isTopicSelectorOpen,
+      setIsTopicSelectorOpen,
+      moveToTopicRequest,
+      setMoveTopicRequest,
     }),
     [
       viewData,
@@ -604,6 +679,13 @@ export const useQuestionTree = (
       cancelModifyMode,
       reparentRequest,
       confirmReparenting,
+      moveToOtherMode,
+      confirmMoveToOtherTopic,
+      nodeToMove,
+      isTopicSelectorOpen,
+      setIsTopicSelectorOpen,
+      moveToTopicRequest,
+      setMoveTopicRequest,
     ]
   );
 };

--- a/front/src/components/ui/command.tsx
+++ b/front/src/components/ui/command.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { SearchIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("bg-border -mx-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}


### PR DESCRIPTION
## "다른 토픽으로 이동" 기능 구현 (토픽 선택 모달 및 그래프 재사용)
### PR 요약 
사용자가 특정 노드 줄기를 기존의 다른 토픽으로 이동시킬 수 있는 기능을 구현했습니다.

예를 들어, 'Oracle' 토픽에 실수로 생성된 '된장찌개' 노드 줄기를, '요리'라는 이름의 기존 토픽으로 옮길 수 있습니다. 

### **주요 변경 사항** 
**1. "다른 토픽으로 이동" 상태  도입**
* useQuestionTree 훅에 moveToOtherMode 함수와 SELECT_NODE_TO_MOVE_OTHER라는 modifyMode 상태를 추가했습니다.
* FocusViewHeader에 [다른 토픽으로 이동] 버튼을 추가하고, modifyMode === 'IDLE'일 때만 보이도록 cancelModifyMode와 로직을 공유합니다.
* 사용자가 [다른 토픽으로 이동] 버튼을 누르면 modifyMode가 변경되고, "이동할 노드를 선택하세요"라는 안내가 표시됩니다.

**2. TopicSelectorModal 컴포넌트 신규 생성** 
사용자가 이동할 '대상'을 선택하는 복잡한 과정을 처리하기 위해 TopicSelectorModal을 새로 구현했습니다. 이 모달은 2단계로 작동합니다.

[1단계: 토픽 선택]

* 모달이 열리면 getTopicsHistory API를 호출하여 모든 토픽 목록을 불러옵니다.
* 현재 토픽은 '순환 참조'를 막기 위해 리스트에서 비활성화(disabled) 처리했습니다.

[2단계: 부모 노드 선택]

* 사용자가 대상 토픽(예: '요리')을 선택하면, getTopicById API를 호출하여 해당 토픽의 전체 ViewData를 불러옵니다.
* 모달 내부에서 InteractiveD3Graph 컴포넌트를 재사용하여 '요리' 토픽의 미니 그래프를 렌더링합니다.
* 사용자가 미니 그래프에서 '한식' 노드를 클릭하면, onNodeSelected 콜백이 (targetTopic, targetParentNode) 정보를 반환하며 모달이 닫힙니다.

**3. 최종 확인 및 API 연동**
* TopicSelectorModal이 닫히면, EnhancedBreadcrumbFocusViewContent는 setMoveToTopicRequest를 호출하여 "최종 확인 모달"(AlertDialog)을 띄웁니다.
* 사용자가 "이동"을 최종 확인하면, confirmMoveToOtherTopic 함수가 실행됩니다.
* 이 함수는 기존의 **copyQuestions**와 deleteQuestionsBatch API를 재사용하여, 선택된 줄기 전체를 복사하고 원본을 삭제합니다.
* refreshViewData()를 호출하여 현재 그래프를 갱신합니다.